### PR TITLE
fix: use supported api version

### DIFF
--- a/js/vk.api.js
+++ b/js/vk.api.js
@@ -27,7 +27,7 @@ var vk = {
     appId: 4388415,
     authScope: 'messages,offline',
     authRedirectUri: 'https://oauth.vk.com/blank.html',
-    versionAPI: "5.80",
+    versionAPI: "5.81",
 
     TIME_BETWEEN_REQUESTS: settings.VK_TIME_BETWEEN_REQUESTS,
     TIME_BETWEEN_FAILED_REQUESTS: 3000,

--- a/manifest.example.json
+++ b/manifest.example.json
@@ -26,5 +26,5 @@
     "tabs", "*://*.userapi.com/*", "*://api.vk.com/*", "*://*.vk.me/*", "*://mc.yandex.ru/*", "*://vk.com/images/*", "storage", "unlimitedStorage"
   ],
   "update_url": "https://clients2.google.com/service/update2/crx",
-  "version": "1.1.6"
+  "version": "1.1.7"
 }


### PR DESCRIPTION
The currently used API version is not supported anymore. So, the extension fails to make any API calls. This PR fixes it