### PR TITLE
Fix problem with messages loading

### DIFF
--- a/js/vk.api.js
+++ b/js/vk.api.js
@@ -378,7 +378,7 @@ var vk = {
 
         var startId = params.startId;
         var endId = params.endId;
-        var msgToLoad = min(endId - startId + 1, 1500);
+        var msgToLoad = min(endId - startId + 1, 100);
 
         if(msgToLoad <= 0)
         {


### PR DESCRIPTION
Currently VK loads only 100 messages per request instead of 1500., which leads to missing of 14/15 of all messages (can be verified by opening _Google Chrome Developer Tools > Application > WebSQL_  and checking ids of messages in the database, which would be in pattern 1-100, 1500-1600, 3000-3100 and so on).

Fix implements simple reducing of messages amount extension expects to get from VK, so it would load them in batches by 100, instead of 1500, thus requesting all of them, although slowly.